### PR TITLE
fix: normalize URLs and improve scan error handling

### DIFF
--- a/src/app/api/scan/route.ts
+++ b/src/app/api/scan/route.ts
@@ -5,11 +5,16 @@ import { runFreeScan } from "@/lib/pipelines/free-scan";
 import type { ApiResponse, ScanResult } from "@/types";
 
 const scanSchema = z.object({
-  url: z.url("Must be a valid URL"),
+  url: z.string().transform((val) => {
+    const trimmed = val.trim();
+    return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  }).pipe(z.url("Must be a valid URL")),
 });
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
 const checkRateLimit = rateLimit({ interval: ONE_HOUR_MS, limit: 5 });
+
+export const maxDuration = 60;
 
 export async function POST(
   request: NextRequest
@@ -55,8 +60,7 @@ export async function POST(
     );
   } catch (error) {
     const isTimeout =
-      error instanceof Error &&
-      (error.name === "AbortError" || error.message.includes("abort"));
+      error instanceof Error && error.name === "AbortError";
 
     if (isTimeout) {
       return NextResponse.json(
@@ -65,10 +69,14 @@ export async function POST(
       );
     }
 
-    console.error("[POST /api/scan] Pipeline error:", error);
-    return NextResponse.json(
-      { error: "An unexpected error occurred during the scan." },
-      { status: 500 }
-    );
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    console.error("[POST /api/scan] Pipeline error:", errorMessage);
+
+    const userMessage = errorMessage.includes("is not configured")
+      ? "Service configuration error. Please contact support."
+      : `Scan failed: ${errorMessage}`;
+
+    return NextResponse.json({ error: userMessage }, { status: 500 });
   }
 }

--- a/src/components/hero/hero-search.tsx
+++ b/src/components/hero/hero-search.tsx
@@ -34,6 +34,10 @@ export function HeroSearch({ onUrlChange }: HeroSearchProps) {
       return;
     }
 
+    const normalizedUrl = /^https?:\/\//i.test(trimmed)
+      ? trimmed
+      : `https://${trimmed}`;
+
     const currentSubmit = ++submitCountRef.current;
     setIsScanning(true);
     setError('');
@@ -42,7 +46,7 @@ export function HeroSearch({ onUrlChange }: HeroSearchProps) {
       const response = await fetch('/api/scan', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url: trimmed }),
+        body: JSON.stringify({ url: normalizedUrl }),
       });
 
       if (currentSubmit !== submitCountRef.current) return;

--- a/src/components/scan-form.tsx
+++ b/src/components/scan-form.tsx
@@ -30,11 +30,15 @@ export function ScanForm() {
 
     setIsLoading(true);
 
+    const normalizedUrl = /^https?:\/\//i.test(trimmed)
+      ? trimmed
+      : `https://${trimmed}`;
+
     try {
       const response = await fetch('/api/scan', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url: trimmed }),
+        body: JSON.stringify({ url: normalizedUrl }),
       });
 
       const data = await response.json();


### PR DESCRIPTION
## Summary
- URL normalization: auto-prepend `https://` to bare domains (e.g., `example.com`) in both API validation and client forms
- Error handling: fix false timeout detection—only `AbortError` triggers 504, other errors return actual messages
- Vercel timeout: add `maxDuration=60s` export for serverless function timeout
- Config errors: clearer error message when API keys are missing

## Changes
- `src/app/api/scan/route.ts`: Schema transform for URL normalization, improved error messages, maxDuration export
- `src/components/scan-form.tsx`: Client-side URL normalization before API call
- `src/components/hero/hero-search.tsx`: Client-side URL normalization before API call

## Test plan
- [x] Submit bare domain (`yourbusiness.com`) from hero search—should normalize to `https://yourbusiness.com`
- [x] Real pipeline errors (e.g., bad API key) should return 500 with actual error message, not 504

🤖 Generated with [Claude Code](https://claude.com/claude-code)