### PR TITLE
fix: improve search query relevance by inferring category from page content

### DIFF
--- a/src/lib/pipelines/free-scan.ts
+++ b/src/lib/pipelines/free-scan.ts
@@ -23,7 +23,7 @@ const MAX_QUERY_LENGTH = 200;
  */
 function sanitizeForPrompt(text: string, maxLength: number = 500): string {
   return text
-    .replace(/[<>`]/g, "")
+    .replace(/[<>`"]/g, "")
     .replace(/\r?\n/g, " ")
     .trim()
     .slice(0, maxLength);
@@ -182,14 +182,14 @@ Return ONLY the JSON object, no explanation.`,
   const objectMatch = text.match(/\{[\s\S]*\}/);
   if (objectMatch) {
     try {
-      const parsed = JSON.parse(objectMatch[0]) as { category?: string; queries?: string[] };
+      const parsed = JSON.parse(objectMatch[0]) as { category?: unknown; queries?: unknown[] };
       if (parsed.queries && Array.isArray(parsed.queries)) {
         const filtered = parsed.queries
           .filter((q): q is string => typeof q === "string" && isValidQuery(q))
           .slice(0, 5);
         if (filtered.length > 0) {
           return {
-            category: sanitizeForPrompt(parsed.category ?? "local business", 100),
+            category: sanitizeForPrompt(typeof parsed.category === "string" ? parsed.category : "local business", 100),
             queries: filtered,
           };
         }


### PR DESCRIPTION
## Summary

Replace brittle keyword-based category inference with Claude-driven detection in the free scan pipeline. Query generation now receives crawled page content and returns both the inferred category and relevant queries in a single API call.

## Changes

- Remove hardcoded keyword list for category inference (never complete, always misses industries)
- Have Claude infer category from actual page description and content during query generation
- Return both category and queries from a single Claude API call
- Pass inferred category through to scan results for accurate business type display

## Why

Businesses in unrecognized industries (e.g. clothing stores) were being treated as generic "local businesses" and matched against wrong industry queries (restaurants by default). Claude now determines the actual business type from page content itself, handling any industry without maintenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)