### PR TITLE
fix: manual re-runs bypass period idempotency check

### DIFF
--- a/src/app/api/admin/clients/[id]/recheck/route.ts
+++ b/src/app/api/admin/clients/[id]/recheck/route.ts
@@ -36,7 +36,7 @@ export async function POST(
   });
 
   // Run in background — don't block the response
-  const promise = runMonthlyCheck(id).catch((err) => {
+  const promise = runMonthlyCheck(id, { force: true }).catch((err) => {
     console.error(`[Admin Recheck] Failed for ${id}:`, err);
   });
 

--- a/src/app/api/dashboard/recheck/route.ts
+++ b/src/app/api/dashboard/recheck/route.ts
@@ -91,7 +91,7 @@ export async function POST(
   }
 
   // Run in background — don't block the response
-  const promise = runMonthlyCheck(clientId).catch((err) => {
+  const promise = runMonthlyCheck(clientId, { force: true }).catch((err) => {
     console.error(`[Dashboard Recheck] Failed for ${clientId}:`, err);
   });
 

--- a/src/lib/pipelines/monthly-check.ts
+++ b/src/lib/pipelines/monthly-check.ts
@@ -56,7 +56,7 @@ async function acquireLock(key: string): Promise<(() => Promise<void>) | null> {
  * exists for this clientId + current month, returns early with existing data.
  * Does NOT delete old citations — all records are historical/append-only.
  */
-export async function runMonthlyCheck(clientId: string): Promise<MonthlyCheckResult> {
+export async function runMonthlyCheck(clientId: string, options?: { force?: boolean }): Promise<MonthlyCheckResult> {
   console.log("[Monthly Check] Starting for client:", clientId);
 
   // Step 1: Load client and validate eligibility
@@ -95,27 +95,30 @@ export async function runMonthlyCheck(clientId: string): Promise<MonthlyCheckRes
 
   try {
 
-  const existingScore = await prisma.visibilityScore.findUnique({
-    where: { clientId_period: { clientId, period } },
-  });
-
-  if (existingScore) {
-    console.log("[Monthly Check] Already ran for this period, returning existing score");
-
-    // Find previous period score for delta
-    const previousScore = await prisma.visibilityScore.findFirst({
-      where: { clientId, period: { lt: period } },
-      orderBy: { period: "desc" },
+  if (!options?.force) {
+    const existingScore = await prisma.visibilityScore.findUnique({
+      where: { clientId_period: { clientId, period } },
     });
 
-    return {
-      clientId,
-      newScore: existingScore.score,
-      previousScore: previousScore?.score ?? null,
-      delta: existingScore.score - (previousScore?.score ?? existingScore.score),
-      filesRegenerated: false,
-      citationsChecked: 0,
-    };
+    if (existingScore) {
+      console.log("[Monthly Check] Already ran for this period, returning existing score");
+
+      const previousScore = await prisma.visibilityScore.findFirst({
+        where: { clientId, period: { lt: period } },
+        orderBy: { period: "desc" },
+      });
+
+      return {
+        clientId,
+        newScore: existingScore.score,
+        previousScore: previousScore?.score ?? null,
+        delta: existingScore.score - (previousScore?.score ?? existingScore.score),
+        filesRegenerated: false,
+        citationsChecked: 0,
+      };
+    }
+  } else {
+    console.log("[Monthly Check] Force mode — skipping idempotency check");
   }
 
   // SSRF validation


### PR DESCRIPTION
## Summary
- Added `force` option to `runMonthlyCheck()` that skips the "already ran this period" early return
- Both dashboard and admin recheck endpoints pass `force: true` so re-runs actually re-run
- Cron job still uses default (no force) for deduplication safety

## Test plan
- [ ] Trigger re-run from dashboard — verify it runs the full pipeline instead of returning cached score
- [ ] Trigger re-run from admin panel — same behavior
- [ ] Verify monthly cron still deduplicates correctly (no force flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)