### PR TITLE
fix: llms.txt shows 'Unknown' city for national/global businesses

### DIFF
--- a/src/app/api/dashboard/client/route.ts
+++ b/src/app/api/dashboard/client/route.ts
@@ -39,6 +39,12 @@ export async function PATCH(
   if (updates.city !== undefined) data.city = updates.city;
   if (updates.state !== undefined) data.state = updates.state;
 
+  // When service area is national/global, clear city/state
+  if (data.serviceArea === "national" || data.serviceArea === "global") {
+    data.city = null;
+    data.state = null;
+  }
+
   if (Object.keys(data).length === 0) {
     return NextResponse.json(
       { error: "No fields to update" },

--- a/src/app/dashboard/[clientId]/page.tsx
+++ b/src/app/dashboard/[clientId]/page.tsx
@@ -472,7 +472,14 @@ function ActiveDashboard({ data }: { data: DashboardData }) {
                       name="profileServiceArea"
                       value={option}
                       checked={profileData.serviceArea === option}
-                      onChange={(e) => setProfileData((prev) => ({ ...prev, serviceArea: e.target.value }))}
+                      onChange={(e) => {
+                        const val = e.target.value;
+                        setProfileData((prev) => ({
+                          ...prev,
+                          serviceArea: val,
+                          ...(val === 'national' || val === 'global' ? { city: '', state: '' } : {}),
+                        }));
+                      }}
                       className="h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500"
                     />
                     {option.charAt(0).toUpperCase() + option.slice(1)}

--- a/src/lib/engines/generators/llms-txt.ts
+++ b/src/lib/engines/generators/llms-txt.ts
@@ -4,10 +4,15 @@ import { sanitizeForPrompt } from "@/lib/utils/sanitize";
 const ENRICHED_ABOUT_TIMEOUT_MS = 10_000;
 
 /**
- * Return trimmed string if non-empty, otherwise undefined.
+ * Return trimmed string if non-empty and not a placeholder, otherwise undefined.
  */
+const PLACEHOLDER_VALUES = new Set(["unknown", "n/a", "none", "null", "undefined", ""]);
+
 function truthy(val: string | undefined): string | undefined {
-  return val && val.trim() ? val.trim() : undefined;
+  if (!val) return undefined;
+  const trimmed = val.trim();
+  if (PLACEHOLDER_VALUES.has(trimmed.toLowerCase())) return undefined;
+  return trimmed;
 }
 
 /**

--- a/src/lib/pipelines/monthly-check.ts
+++ b/src/lib/pipelines/monthly-check.ts
@@ -148,6 +148,8 @@ export async function runMonthlyCheck(clientId: string, options?: { force?: bool
   // Update client — only fill in fields that are currently empty/junk.
   // Never overwrite user-edited values (profile editor sets real names/categories).
   const isUrlLikeName = (name: string) => /^https?:\/\/|\.com|\.org|\.net/i.test(name);
+  const PLACEHOLDERS = new Set(["unknown", "n/a", "none", "null", "undefined", ""]);
+  const isPlaceholder = (val: string | null | undefined) => !val || PLACEHOLDERS.has(val.trim().toLowerCase());
   const updateData: Record<string, unknown> = {};
 
   // Only update businessName if current value looks like a URL/domain
@@ -158,9 +160,16 @@ export async function runMonthlyCheck(clientId: string, options?: { force?: bool
         : enriched?.businessName ?? client.businessName;
   }
 
-  // Only backfill nullable fields if currently empty
-  if (!client.city) updateData.city = crawlResult.city || enriched?.city || null;
-  if (!client.state) updateData.state = crawlResult.state || enriched?.state || null;
+  // Clear city/state for national/global businesses
+  const effectiveServiceArea = client.serviceArea || enriched?.serviceArea;
+  if (effectiveServiceArea === "national" || effectiveServiceArea === "global") {
+    if (client.city) updateData.city = null;
+    if (client.state) updateData.state = null;
+  } else {
+    // Only backfill nullable fields if currently empty or placeholder
+    if (isPlaceholder(client.city)) updateData.city = crawlResult.city || enriched?.city || null;
+    if (isPlaceholder(client.state)) updateData.state = crawlResult.state || enriched?.state || null;
+  }
   if (!client.phone) updateData.phone = crawlResult.phone || null;
   if (!client.address) updateData.address = crawlResult.address || null;
   if (!client.category) updateData.category = crawlResult.category || enriched?.category || null;


### PR DESCRIPTION
## Summary
- **llms-txt generator**: `truthy()` now rejects placeholder values ("Unknown", "N/A", "None", etc.) so they don't appear in output
- **Profile editor**: Switching service area to national/global auto-clears city/state fields in the form
- **PATCH endpoint**: Force-nulls city/state in the DB when serviceArea is set to national/global
- **Monthly check pipeline**: Clears city/state for national/global businesses during re-runs, treats placeholder values as empty when backfilling

## Test plan
- [ ] Edit huegahouse profile to Global, save — verify city/state are nulled in DB
- [ ] Re-run report — verify llms.txt says "customers worldwide" not "in Unknown"
- [ ] Edit a local business profile — verify city/state still work normally
- [ ] Verify llms.txt title uses business name, not URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)