### PR TITLE
fix: prevent llms.txt feedback loop poisoning business name

### DIFF
--- a/src/lib/engines/crawler.ts
+++ b/src/lib/engines/crawler.ts
@@ -56,9 +56,11 @@ async function crawlWithFirecrawl(
 function parseFirecrawlResponse(content: string, sourceUrl: string): CrawlResult {
   const lines = content.split("\n");
 
-  // Extract business name from first heading
+  // Extract business name from first heading (skip URL-like titles — often from llms.txt files)
   const titleLine = lines.find((l) => l.startsWith("# "));
-  const businessName = titleLine?.replace(/^#\s+/, "").trim() || extractDomainName(sourceUrl);
+  const rawTitle = titleLine?.replace(/^#\s+/, "").trim();
+  const isUrlLikeTitle = rawTitle && /^https?:\/\/|^www\./i.test(rawTitle);
+  const businessName = (rawTitle && !isUrlLikeTitle) ? rawTitle : extractDomainName(sourceUrl);
 
   // Extract description from blockquote
   const descLine = lines.find((l) => l.startsWith("> "));

--- a/src/lib/pipelines/monthly-check.ts
+++ b/src/lib/pipelines/monthly-check.ts
@@ -147,7 +147,7 @@ export async function runMonthlyCheck(clientId: string, options?: { force?: bool
 
   // Update client — only fill in fields that are currently empty/junk.
   // Never overwrite user-edited values (profile editor sets real names/categories).
-  const isUrlLikeName = (name: string) => /^https?:\/\/|\.com|\.org|\.net/i.test(name);
+  const isUrlLikeName = (name: string) => /^https?:\/\/|^www\.|\.com\b|\.org\b|\.net\b/i.test(name);
   const PLACEHOLDERS = new Set(["unknown", "n/a", "none", "null", "undefined", ""]);
   const isPlaceholder = (val: string | null | undefined) => !val || PLACEHOLDERS.has(val.trim().toLowerCase());
   const updateData: Record<string, unknown> = {};

--- a/src/lib/pipelines/setup.ts
+++ b/src/lib/pipelines/setup.ts
@@ -118,13 +118,21 @@ async function executeSetupSteps(clientId: string): Promise<void> {
   }
 
   // Step 3: Update client with crawled data (priority: user-provided > crawl > enriched > existing)
-  // Business name: if it looks like a domain (no spaces), prefer crawl/enriched over it
-  const isLikelyDomainName = !client.businessName.includes(" ");
+  // Business name: replace if current value looks like a URL/domain (not a real name)
+  const isUrlLikeName = (name: string) => /^https?:\/\/|^www\.|\.com\b|\.org\b|\.net\b/i.test(name);
+  const needsNameReplacement = isUrlLikeName(client.businessName);
+  const bestCrawlName = crawlResult.businessName && !isUrlLikeName(crawlResult.businessName)
+    ? crawlResult.businessName
+    : null;
+  const bestEnrichedName = enrichedData.businessName && !isUrlLikeName(enrichedData.businessName)
+    ? enrichedData.businessName
+    : null;
+
   await prisma.client.update({
     where: { id: clientId },
     data: {
-      businessName: isLikelyDomainName
-        ? (crawlResult.businessName || enrichedData.businessName || client.businessName)
+      businessName: needsNameReplacement
+        ? (bestCrawlName || bestEnrichedName || client.businessName)
         : client.businessName,
       city: client.city || crawlResult.city || enrichedData.city || null,
       state: client.state || crawlResult.state || enrichedData.state || null,


### PR DESCRIPTION
## Summary
Root cause of garbage llms.txt: Firecrawl crawls the client's site **including our own generated llms.txt file**. The crawler extracts the first `# heading` as the business name, so `# https://huegahouse.com llms.txt` becomes the stored business name. The setup pipeline's "has spaces = real name" heuristic then preserves this garbage permanently.

- **Crawler**: Skip URL-like titles (`https://`, `www.`) when extracting business names from headings
- **Setup pipeline**: Replace naive space-check with proper URL pattern detection (`/^https?:\/\/|^www\.|\.com\b|\.org\b|\.net\b/`); also validates that crawler/enricher suggestions aren't URL-like before accepting them
- **Monthly check**: Same URL detection improvement with word boundaries

## Test plan
- [ ] Re-run for huegahouse.com after fixing business name in profile editor — verify llms.txt uses real name
- [ ] New client signup with no business name provided — verify domain fallback works, not URL
- [ ] Client with existing llms.txt on their site — verify crawler doesn't extract URL as name

🤖 Generated with [Claude Code](https://claude.com/claude-code)