### PR TITLE
chore: reduce generated file cache TTL from 1hr to 60s

### DIFF
--- a/src/app/api/geo/llms/[clientId]/llms.txt/route.ts
+++ b/src/app/api/geo/llms/[clientId]/llms.txt/route.ts
@@ -33,7 +33,7 @@ export async function GET(
       headers: {
         "Content-Type": "text/plain; charset=utf-8",
         "X-Content-Type-Options": "nosniff",
-        "Cache-Control": "public, max-age=3600",
+        "Cache-Control": "public, max-age=60, stale-while-revalidate=300",
       },
     });
   } catch (error) {

--- a/src/app/api/geo/schema/[clientId]/route.ts
+++ b/src/app/api/geo/schema/[clientId]/route.ts
@@ -33,7 +33,7 @@ export async function GET(
       headers: {
         "Content-Type": "application/ld+json; charset=utf-8",
         "X-Content-Type-Options": "nosniff",
-        "Cache-Control": "public, max-age=3600",
+        "Cache-Control": "public, max-age=60, stale-while-revalidate=300",
       },
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- Reduces `Cache-Control` on llms.txt and schema JSON-LD serving routes from `max-age=3600` (1 hour) to `max-age=60, stale-while-revalidate=300`
- Changes from re-runs are now visible within a minute instead of waiting an hour

## Test plan
- [ ] Check response headers on llms.txt endpoint — verify `max-age=60`
- [ ] Re-run report, wait 60s, verify updated content is served

🤖 Generated with [Claude Code](https://claude.com/claude-code)