### PR TITLE
feat(security-scan): encrypted-column exclusion P0 rule (FOR-34)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ yarn-error.log*
 next-env.d.ts
 
 /src/generated/prisma
+
+# security scan reports
+/.security-scan

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "postinstall": "prisma generate",
     "build": "prisma generate && next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "security:scan": "tsx scripts/security-scan/scan.ts",
+    "test:security": "tsx --test scripts/security-scan/rules/__tests__/*.test.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",

--- a/scripts/security-scan/rules/__tests__/encrypted-column-exclusion.test.ts
+++ b/scripts/security-scan/rules/__tests__/encrypted-column-exclusion.test.ts
@@ -1,0 +1,164 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { check, type DiffFile } from '../encrypted-column-exclusion.ts';
+
+const MODELS = ['Payment'];
+
+function makeFile(path: string, content: string): DiffFile {
+  return { path, content };
+}
+
+describe('encrypted-column-exclusion rule', () => {
+  describe('positive cases (should flag P0)', () => {
+    it('flags bare findUnique with no select', () => {
+      const findings = check(
+        [makeFile('src/lib/payments.ts', 'const p = await prisma.payment.findUnique({ where: { id } });')],
+        { models: MODELS },
+      );
+      assert.equal(findings.length, 1);
+      assert.equal(findings[0].severity, 'P0');
+      assert.equal(findings[0].category, 'encrypted-column-exclusion');
+      assert.equal(findings[0].file, 'src/lib/payments.ts');
+      assert.match(findings[0].message, /findUnique/);
+      assert.match(findings[0].remediation, /gpu-var-platform-spec §15/);
+    });
+
+    it('flags bare findMany with no select', () => {
+      const findings = check(
+        [makeFile('src/lib/payments.ts', 'const rows = await prisma.payment.findMany({ where: { userId } });')],
+        { models: MODELS },
+      );
+      assert.equal(findings.length, 1);
+      assert.equal(findings[0].severity, 'P0');
+    });
+
+    it('flags bare findFirst with no select', () => {
+      const findings = check(
+        [makeFile('src/lib/payments.ts', 'const row = await prisma.payment.findFirst({ where: { id } });')],
+        { models: MODELS },
+      );
+      assert.equal(findings.length, 1);
+    });
+
+    it('flags bare findManyRaw with no select', () => {
+      const findings = check(
+        [makeFile('src/lib/payments.ts', 'const rows = await prisma.payment.findManyRaw({ query: { id } });')],
+        { models: MODELS },
+      );
+      assert.equal(findings.length, 1);
+    });
+
+    it('flags call with empty args (no select)', () => {
+      const findings = check(
+        [makeFile('src/lib/payments.ts', 'const p = await prisma.payment.findUnique();')],
+        { models: MODELS },
+      );
+      assert.equal(findings.length, 1);
+    });
+
+    it('reports correct line number for call on line 2', () => {
+      const content = 'const x = 1;\nconst p = await prisma.payment.findUnique({ where: { id } });\n';
+      const findings = check([makeFile('src/lib/payments.ts', content)], { models: MODELS });
+      assert.equal(findings[0].line, 2);
+    });
+  });
+
+  describe('negative cases (should not flag)', () => {
+    it('passes findUnique with select that omits encrypted field', () => {
+      const content = `
+        const p = await prisma.payment.findUnique({
+          where: { id },
+          select: { id: true, amount: true, createdAt: true },
+        });
+      `;
+      const findings = check([makeFile('src/lib/payments.ts', content)], { models: MODELS });
+      assert.equal(findings.length, 0);
+    });
+
+    it('passes findMany with select clause', () => {
+      const content = `
+        const rows = await prisma.payment.findMany({
+          where: { userId },
+          select: { id: true, amount: true },
+        });
+      `;
+      const findings = check([makeFile('src/lib/payments.ts', content)], { models: MODELS });
+      assert.equal(findings.length, 0);
+    });
+
+    it('does not flag models without encrypted fields', () => {
+      const findings = check(
+        [makeFile('src/lib/users.ts', 'const u = await prisma.user.findUnique({ where: { id } });')],
+        { models: MODELS },
+      );
+      assert.equal(findings.length, 0);
+    });
+
+    it('returns empty when no encrypted models provided', () => {
+      const findings = check(
+        [makeFile('src/lib/payments.ts', 'const p = await prisma.payment.findUnique({ where: { id } });')],
+        { models: [] },
+      );
+      assert.equal(findings.length, 0);
+    });
+
+    it('does not flag write operations (create, update, delete)', () => {
+      const content = `
+        await prisma.payment.create({ data: { amount: 100 } });
+        await prisma.payment.update({ where: { id }, data: { amount: 200 } });
+        await prisma.payment.delete({ where: { id } });
+      `;
+      const findings = check([makeFile('src/lib/payments.ts', content)], { models: MODELS });
+      assert.equal(findings.length, 0);
+    });
+  });
+
+  describe('schema parsing via schemaPath', () => {
+    it('detects encrypted model from schema and flags bare call', () => {
+      const schemaPath = join(tmpdir(), `schema-${Date.now()}.prisma`);
+      writeFileSync(schemaPath, `
+model Payment {
+  id                   String  @id
+  amount               Int
+  cardNumber_encrypted String
+}
+
+model User {
+  id   String @id
+  name String
+}
+`);
+
+      const findings = check(
+        [makeFile('src/lib/payments.ts', 'const p = await prisma.payment.findUnique({ where: { id } });')],
+        { schemaPath },
+      );
+      assert.equal(findings.length, 1, 'should flag Payment model (has encrypted field)');
+    });
+
+    it('does not flag a model without encrypted fields from schema', () => {
+      const schemaPath = join(tmpdir(), `schema-${Date.now()}.prisma`);
+      writeFileSync(schemaPath, `
+model Payment {
+  id                   String  @id
+  amount               Int
+  cardNumber_encrypted String
+}
+
+model User {
+  id   String @id
+  name String
+}
+`);
+
+      const findings = check(
+        [makeFile('src/lib/users.ts', 'const u = await prisma.user.findUnique({ where: { id } });')],
+        { schemaPath },
+      );
+      assert.equal(findings.length, 0, 'should not flag User model (no encrypted fields)');
+    });
+  });
+});

--- a/scripts/security-scan/rules/encrypted-column-exclusion.ts
+++ b/scripts/security-scan/rules/encrypted-column-exclusion.ts
@@ -1,0 +1,133 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export interface Finding {
+  severity: 'P0' | 'P1' | 'P2';
+  category: string;
+  file: string;
+  line: number;
+  message: string;
+  remediation: string;
+}
+
+export interface DiffFile {
+  path: string;
+  content: string;
+}
+
+const READ_METHODS = ['findMany', 'findUnique', 'findFirst', 'findManyRaw'] as const;
+
+const DEFAULT_SCHEMA_PATH = resolve(process.cwd(), 'prisma/schema.prisma');
+
+const REMEDIATION =
+  'Add a `select` clause that explicitly lists the fields to return, omitting all `*_encrypted` fields. ' +
+  'See gpu-var-platform-spec §15 §"Read-Path Column Discipline (Encrypted-Column Exclusion)".';
+
+function toCamelCase(name: string): string {
+  return name.charAt(0).toLowerCase() + name.slice(1);
+}
+
+function parseEncryptedModels(schemaPath: string): string[] {
+  let schema: string;
+  try {
+    schema = readFileSync(schemaPath, 'utf8');
+  } catch {
+    return [];
+  }
+
+  const models: string[] = [];
+  const lines = schema.split('\n');
+  let currentModel: string | null = null;
+  let hasEncrypted = false;
+  let depth = 0;
+
+  for (const line of lines) {
+    const modelMatch = line.match(/^model\s+(\w+)\s*\{/);
+    if (modelMatch && depth === 0) {
+      currentModel = modelMatch[1];
+      hasEncrypted = false;
+      depth = 1;
+      continue;
+    }
+
+    if (currentModel !== null) {
+      for (const ch of line) {
+        if (ch === '{') depth++;
+        else if (ch === '}') depth--;
+      }
+
+      if (depth === 0) {
+        if (hasEncrypted) models.push(currentModel);
+        currentModel = null;
+        hasEncrypted = false;
+      } else if (/^\s+\w*_encrypted\b/.test(line)) {
+        hasEncrypted = true;
+      }
+    }
+  }
+
+  return models;
+}
+
+function extractCallArgs(content: string, openParenIndex: number): string {
+  let depth = 0;
+  let i = openParenIndex;
+  while (i < content.length) {
+    if (content[i] === '(') depth++;
+    else if (content[i] === ')') {
+      depth--;
+      if (depth === 0) return content.slice(openParenIndex + 1, i);
+    }
+    i++;
+  }
+  return '';
+}
+
+function lineNumberAt(content: string, index: number): number {
+  return content.slice(0, index).split('\n').length;
+}
+
+export interface CheckOptions {
+  schemaPath?: string;
+  models?: string[];
+}
+
+export function check(diff: DiffFile[], options: CheckOptions = {}): Finding[] {
+  const models =
+    options.models ??
+    parseEncryptedModels(options.schemaPath ?? DEFAULT_SCHEMA_PATH);
+
+  if (models.length === 0) return [];
+
+  const camelModels = models.map(toCamelCase);
+  const methodRe = new RegExp(
+    `\\bprisma\\.(${camelModels.join('|')})\\.(${READ_METHODS.join('|')})\\(`,
+    'g',
+  );
+
+  const findings: Finding[] = [];
+
+  for (const file of diff) {
+    methodRe.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = methodRe.exec(file.content)) !== null) {
+      const openParenIndex = match.index + match[0].length - 1;
+      const args = extractCallArgs(file.content, openParenIndex);
+      if (!/\bselect\s*:/.test(args)) {
+        const modelName = match[1];
+        const method = match[2];
+        findings.push({
+          severity: 'P0',
+          category: 'encrypted-column-exclusion',
+          file: file.path,
+          line: lineNumberAt(file.content, match.index),
+          message:
+            `\`prisma.${modelName}.${method}()\` targets a model with \`*_encrypted\` fields but has no explicit \`select\` clause — encrypted columns may be inadvertently returned.`,
+          remediation: REMEDIATION,
+        });
+      }
+    }
+  }
+
+  return findings;
+}

--- a/scripts/security-scan/scan.ts
+++ b/scripts/security-scan/scan.ts
@@ -1,0 +1,83 @@
+import { execSync } from 'node:child_process';
+import { readFileSync, mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { check as checkEncryptedColumns, type Finding, type DiffFile } from './rules/encrypted-column-exclusion.ts';
+
+const REPORT_DIR = resolve(process.cwd(), '.security-scan');
+
+function getChangedFiles(base: string): string[] {
+  try {
+    const out = execSync(`git diff --name-only ${base}`, { encoding: 'utf8' });
+    return out.trim().split('\n').filter(Boolean);
+  } catch {
+    console.error(`Failed to get diff against ${base}`);
+    process.exit(1);
+  }
+}
+
+function loadDiffFiles(paths: string[]): DiffFile[] {
+  return paths
+    .filter(p => /\.(ts|tsx|js|jsx|mts|mjs)$/.test(p))
+    .map(p => {
+      const abs = resolve(process.cwd(), p);
+      if (!existsSync(abs)) return null;
+      return { path: p, content: readFileSync(abs, 'utf8') };
+    })
+    .filter((f): f is DiffFile => f !== null);
+}
+
+function getCommitSha(): string {
+  try {
+    return execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+function parseArgs(args: string[]): { base: string } {
+  const diffIndex = args.indexOf('--diff');
+  const base = diffIndex !== -1 ? args[diffIndex + 1] : 'origin/main';
+  return { base };
+}
+
+function main() {
+  const { base } = parseArgs(process.argv.slice(2));
+
+  console.log(`Running security scan against ${base}...`);
+
+  const changedPaths = getChangedFiles(base);
+  if (changedPaths.length === 0) {
+    console.log('No changed files found.');
+    process.exit(0);
+  }
+
+  const diff = loadDiffFiles(changedPaths);
+  const findings: Finding[] = [
+    ...checkEncryptedColumns(diff),
+  ];
+
+  const sha = getCommitSha();
+  mkdirSync(REPORT_DIR, { recursive: true });
+  const reportPath = join(REPORT_DIR, `${sha}.json`);
+  writeFileSync(reportPath, JSON.stringify({ sha, findings }, null, 2));
+
+  const p0 = findings.filter(f => f.severity === 'P0');
+
+  if (findings.length === 0) {
+    console.log('No findings.');
+  } else {
+    for (const f of findings) {
+      console.log(`[${f.severity}] ${f.file}:${f.line} — ${f.message}`);
+    }
+  }
+
+  console.log(`\nReport written to ${reportPath}`);
+  console.log(`Total: ${findings.length} finding(s), ${p0.length} P0`);
+
+  if (p0.length > 0) {
+    console.error('\nFAILED: P0 findings block merge.');
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

- Adds `scripts/security-scan/rules/encrypted-column-exclusion.ts` — P0 rule that detects Prisma read calls (`findMany`, `findUnique`, `findFirst`, `findManyRaw`) on models with `*_encrypted` fields that lack an explicit `select` clause
- Adds 13-test suite under `scripts/security-scan/rules/__tests__/` covering all four read methods, line number reporting, schema parsing, and all negative cases (select present, non-encrypted model, write ops)
- Adds `scripts/security-scan/scan.ts` entrypoint (`pnpm run security:scan -- --diff <base>`) that writes a JSON report to `.security-scan/<sha>.json` and exits non-zero on any P0 finding
- Adds `security:scan` and `test:security` npm scripts; ignores `.security-scan/` in `.gitignore`

Closes FOR-34. Implements gpu-var-platform-spec §15 §"Read-Path Column Discipline (Encrypted-Column Exclusion)".

## Test plan

- [x] `pnpm run test:security` — 13/13 pass
- [x] `pnpm run security:scan -- --diff HEAD` — exits 0 with no findings (current schema has no `*_encrypted` fields)
- [ ] Add a model with a `*_encrypted` field and a bare `findUnique` — confirm P0 finding and non-zero exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)