### PR TITLE
feat(ci): wire encrypted-column P0 scan into CI gate (FOR-35)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,94 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run typecheck
+
+  test-security-rules:
+    name: Security Rule Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run test:security
+
+  security-scan:
+    name: Security Scan (Encrypted-Column Exclusion)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref }}
+      - name: Run security scan
+        run: npm run security:scan -- --diff origin/${{ github.base_ref }}
+      - name: Upload security report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-scan-report-${{ github.sha }}
+          path: .security-scan/
+
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck, test-security-rules, security-scan]
+    if: always()
+    steps:
+      - name: Assert all required checks passed
+        run: |
+          echo "lint:                ${{ needs.lint.result }}"
+          echo "typecheck:           ${{ needs.typecheck.result }}"
+          echo "test-security-rules: ${{ needs.test-security-rules.result }}"
+          echo "security-scan:       ${{ needs.security-scan.result }}"
+
+          fail=0
+
+          [[ "${{ needs.lint.result }}" == "success" ]] || { echo "FAIL: lint"; fail=1; }
+          [[ "${{ needs.typecheck.result }}" == "success" ]] || { echo "FAIL: typecheck"; fail=1; }
+          [[ "${{ needs.test-security-rules.result }}" == "success" ]] || { echo "FAIL: test-security-rules"; fail=1; }
+
+          # security-scan only runs on pull_request events; treat skipped as pass on push to main
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            [[ "${{ needs.security-scan.result }}" == "success" ]] || { echo "FAIL: security-scan"; fail=1; }
+          fi
+
+          [[ $fail -eq 0 ]] && echo "All checks passed." || exit 1

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "security:scan": "tsx scripts/security-scan/scan.ts",
     "test:security": "tsx --test scripts/security-scan/rules/__tests__/*.test.ts"
   },


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` with **lint**, **typecheck**, **test-security-rules**, and **security-scan** jobs
- `security-scan` job runs `npm run security:scan -- --diff origin/${{ github.base_ref }}` on every PR against its base branch; uploads `.security-scan/*.json` as a build artifact
- `ci-gate` sentinel job `needs` all four jobs — add `CI Gate` as the single required check in branch protection for one-line enforcement promotion when GitHub Pro lands
- Adds `typecheck: tsc --noEmit` to `package.json`

## Verification — test branch scan output

Test branch `test/FOR-35-scan-verification` (commit `3042ea3`) added a temporary `apiKey_encrypted` field to the `User` model and a bare `prisma.user.findMany()` call. Scan output:

```
Running security scan against feat/FOR-34-encrypted-column-exclusion...
[P0] src/test-bad-query.ts:5 — `prisma.user.findMany()` targets a model with `*_encrypted` fields but has no explicit `select` clause — encrypted columns may be inadvertently returned.
[P0] src/test-bad-query.ts:6 — `prisma.user.findMany()` targets a model with `*_encrypted` fields but has no explicit `select` clause — encrypted columns may be inadvertently returned.

Total: 2 finding(s), 2 P0
FAILED: P0 findings block merge.
Exit code: 1
```

Test branch was deleted after verification; the schema change and bad-query file are not in this PR.

## Test plan

- [ ] Merge `feat/FOR-34-encrypted-column-exclusion` into main first (or merge this PR on top of it)
- [ ] Add `CI Gate` as a required check in GitHub branch protection settings
- [ ] Confirm a PR with a bare Prisma read on an encrypted-column model fails the `security-scan` job and blocks the `CI Gate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)